### PR TITLE
[feat] 리셀 재고 차감 기능 구현

### DIFF
--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -16,8 +16,6 @@ import com.limito.limitoresellproduct.presentation.dto.response.ProductGetRespon
 import com.limito.limitoresellproduct.presentation.dto.response.ProductReadResponseV1;
 
 import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -26,7 +24,7 @@ public class ResellProductService {
 
 	private final ResellProductRepository resellProductRepository;
 
-	public ProductCreateResponseV1 createProduct(@Valid ProductCreateRequestV1 request) {
+	public ProductCreateResponseV1 createProduct(ProductCreateRequestV1 request) {
 		Product product = ProductMapper.toEntity(request);
 		Product savedProduct = resellProductRepository.saveProduct(product);
 		return ProductMapper.toProductCreateResponseV1(savedProduct);
@@ -44,7 +42,7 @@ public class ResellProductService {
 		return ProductReadResponseV1.of(categoryId, products);
 	}
 
-	public ProductGetResponseV1 getProduct(@NotNull(message = "") UUID resellProductId) {
+	public ProductGetResponseV1 getProduct(UUID resellProductId) {
 		Product product = resellProductRepository.findById(resellProductId);
 		return ProductMapper.toProductGetResponseV1(product);
 	}

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
@@ -6,13 +6,18 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 
 import com.limito.limitoresellproduct.domain.model.Stock;
+import com.limito.limitoresellproduct.domain.model.Stocks;
 import com.limito.limitoresellproduct.domain.repository.ResellStockRepository;
 import com.limito.limitoresellproduct.domain.repository.StockInMemoryRepository;
 import com.limito.limitoresellproduct.infrastructure.persistence.mapper.ProductMapper;
+import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
 import com.limito.limitoresellproduct.presentation.dto.request.StockCreateRequestV1;
+import com.limito.limitoresellproduct.presentation.dto.request.StockReduceRequest;
 import com.limito.limitoresellproduct.presentation.dto.response.StockCreateResponseV1;
+import com.limito.limitoresellproduct.presentation.dto.response.StockReduceResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.StockReserveResponseV1;
 
+import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -24,7 +29,7 @@ public class ResellStockService {
 	private final ResellStockRepository resellStockRepository;
 	private final StockInMemoryRepository stockInMemoryRepository;
 
-	private static final String REDIS_STOCK_PREFIX_KEY = "resell-stock";
+	private static final String REDIS_STOCK_PREFIX_KEY = "resell-stock:";
 
 	public StockCreateResponseV1 createStock(@Valid StockCreateRequestV1 request) {
 		Stock stock = ProductMapper.toEntity(request);
@@ -36,7 +41,7 @@ public class ResellStockService {
 		productService.changeMinimumPriceStock(
 			request.getProductId(),
 			savedStock.getOptionId(),
-			savedStock.getStockId(),
+			savedStock.getId(),
 			savedStock.getPrice()
 		);
 
@@ -71,5 +76,76 @@ public class ResellStockService {
 
 		stockInMemoryRepository.set(REDIS_STOCK_PREFIX_KEY + stockId, "1");
 		return null;
+	}
+
+	@Transactional
+	public StockReduceResponseV1 reduceStocks(@Valid List<StockReduceRequest> requests) {
+		StockReduceResponseV1 result = null;
+		ProductErrorCode failReason = null;
+
+		for (StockReduceRequest request : requests) {
+			failReason = reduceStock(request);
+		}
+
+		if (failReason != null) {
+			List<UUID> stockIds = requests.stream()
+				.map(StockReduceRequest::getStockId)
+				.toList();
+			result = ProductMapper.toStockReduceResponseV1(failReason, stockIds);
+		}
+
+		return result;
+	}
+
+	private ProductErrorCode reduceStock(StockReduceRequest request) {
+		UUID stockId = request.getStockId();
+		UUID optionId = request.getOptionId();
+		UUID productId = request.getProductId();
+		ProductErrorCode failReason = null;
+
+		failReason = deleteReservedStock(stockId);
+		if (failReason != null) {
+			return failReason;
+		}
+
+		failReason = deleteStock(stockId);
+		if (failReason != null) {
+			return failReason;
+		}
+
+		refreshMinStockOfOption(productId, optionId);
+		return failReason;
+	}
+
+	private ProductErrorCode deleteReservedStock(UUID stockId) {
+		String key = REDIS_STOCK_PREFIX_KEY + stockId;
+
+		String reservedStock = stockInMemoryRepository.get(key);
+		if (reservedStock == null) {
+			return ProductErrorCode.WRONG_ID;
+		}
+
+		stockInMemoryRepository.delete(key);
+		return null;
+	}
+
+	private ProductErrorCode deleteStock(UUID stockId) {
+		Stock stock = resellStockRepository.findById(stockId);
+		if (stock == null) {
+			return ProductErrorCode.WRONG_ID;
+		}
+
+		if (stock.isDeleted()) {
+			return ProductErrorCode.OUT_OF_STOCK;
+		}
+
+		resellStockRepository.deleteStock(stock);
+		return null;
+	}
+
+	private void refreshMinStockOfOption(UUID productId, UUID optionId) {
+		List<Stock> stocks = resellStockRepository.findAllByOptionId(optionId);
+		Stock minStock = Stocks.calculateMinStock(stocks);
+		productService.changeMinimumPriceStock(productId, optionId, minStock.getId(), minStock.getPrice());
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
@@ -26,7 +26,7 @@ public class Stock {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)
-	private UUID stockId;
+	private UUID id;
 
 	@Column(name = "option_id", nullable = false)
 	private UUID optionId;

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stocks.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stocks.java
@@ -1,0 +1,16 @@
+package com.limito.limitoresellproduct.domain.model;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class Stocks {
+	private List<Stock> stocks;
+
+	public static Stock calculateMinStock(List<Stock> stocks) {
+		Stock minStock = stocks.stream()
+			.min(Comparator.comparing(Stock::getPrice))
+			.orElse(null);
+
+		return minStock;
+	}
+}

--- a/src/main/java/com/limito/limitoresellproduct/domain/repository/ResellStockRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/repository/ResellStockRepository.java
@@ -1,5 +1,6 @@
 package com.limito.limitoresellproduct.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import com.limito.limitoresellproduct.domain.model.Stock;
@@ -9,4 +10,8 @@ public interface ResellStockRepository {
 	Stock saveStock(Stock stock);
 
 	Stock findById(UUID stockId);
+
+	void deleteStock(Stock stock);
+
+	List<Stock> findAllByOptionId(UUID optionId);
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/repository/StockInMemoryRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/repository/StockInMemoryRepository.java
@@ -5,4 +5,6 @@ public interface StockInMemoryRepository {
 	String get(String key);
 
 	void set(String key, String value);
+
+	void delete(String key);
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/mapper/ProductMapper.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/mapper/ProductMapper.java
@@ -1,6 +1,7 @@
 package com.limito.limitoresellproduct.infrastructure.persistence.mapper;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
@@ -8,11 +9,13 @@ import com.limito.limitoresellproduct.domain.model.Product;
 import com.limito.limitoresellproduct.domain.model.Stock;
 import com.limito.limitoresellproduct.domain.vo.MinimumPriceStock;
 import com.limito.limitoresellproduct.domain.vo.Option;
+import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
 import com.limito.limitoresellproduct.presentation.dto.request.ProductCreateRequestV1;
 import com.limito.limitoresellproduct.presentation.dto.request.StockCreateRequestV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductCreateResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductGetResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.StockCreateResponseV1;
+import com.limito.limitoresellproduct.presentation.dto.response.StockReduceResponseV1;
 
 import jakarta.validation.Valid;
 
@@ -70,7 +73,7 @@ public class ProductMapper {
 
 	public static StockCreateResponseV1 toDto(Stock stock) {
 		return StockCreateResponseV1.builder()
-			.stockId(stock.getStockId())
+			.stockId(stock.getId())
 			.optionId(stock.getOptionId())
 			.price(stock.getPrice())
 			.isDeleted(stock.isDeleted())
@@ -110,6 +113,14 @@ public class ProductMapper {
 			.productName(product.getName())
 			.brandName(product.getBrandName())
 			.options(mappedOptions)
+			.build();
+	}
+
+	public static StockReduceResponseV1 toStockReduceResponseV1(ProductErrorCode failReason, List<UUID> stockIds) {
+		return StockReduceResponseV1.builder()
+			.errorCode(failReason.getMessage().substring(0, 4))
+			.message(failReason.getMessage().substring(7))
+			.stockIds(stockIds)
 			.build();
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellStockJpaRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellStockJpaRepository.java
@@ -1,5 +1,6 @@
 package com.limito.limitoresellproduct.infrastructure.persistence.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.limito.limitoresellproduct.domain.model.Stock;
 
 public interface ResellStockJpaRepository extends JpaRepository<Stock, UUID> {
+	List<Stock> findAllByOptionId(UUID optionId);
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellStockRepositoryImpl.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellStockRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.limito.limitoresellproduct.infrastructure.persistence.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
@@ -23,5 +24,15 @@ public class ResellStockRepositoryImpl implements ResellStockRepository {
 	@Override
 	public Stock findById(UUID stockId) {
 		return jpaRepository.findById(stockId).orElse(null);
+	}
+
+	@Override
+	public void deleteStock(Stock stock) {
+		jpaRepository.delete(stock);
+	}
+
+	@Override
+	public List<Stock> findAllByOptionId(UUID optionId) {
+		return jpaRepository.findAllByOptionId(optionId);
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/redis/StockInMemoryRepositoryImpl.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/redis/StockInMemoryRepositoryImpl.java
@@ -13,15 +13,22 @@ import lombok.RequiredArgsConstructor;
 public class StockInMemoryRepositoryImpl implements StockInMemoryRepository {
 
 	private final StringRedisTemplate stringRedisTemplate;
-	private final ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
 
 	@Override
 	public String get(String key) {
+		ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
 		return ops.get(key);
 	}
 
 	@Override
 	public void set(String key, String value) {
+		ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
 		ops.set(key, value);
+	}
+
+	@Override
+	public void delete(String key) {
+		ValueOperations<String, String> ops = stringRedisTemplate.opsForValue();
+		ops.getAndDelete(key);
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
@@ -11,6 +11,8 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
 	INVALID_DOMAIN_INFO(HttpStatus.BAD_REQUEST, "잘못된 도메인 정보입니다."),
+	WRONG_ID(HttpStatus.BAD_REQUEST, "E001 : 잘못된 리셀 상품 재고 ID입니다."),
+	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "E002 : 재고 부족"),
 	;
 
 	private HttpStatus status;

--- a/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductController.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductController.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
@@ -39,7 +39,7 @@ public class ResellProductInternalController {
 
 	@PostMapping("/reduce")
 	public ResponseEntity<InternalResponse> reduceStock(@Valid @RequestBody List<StockReduceRequest> request) {
-		checkRole("USER");
+		// checkRole("USER");
 		StockReduceResponseV1 response = resellStockService.reduceStocks(request);
 		return makeResponseWithHttpStatus(response);
 	}

--- a/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
@@ -16,6 +16,8 @@ import com.limito.common.exception.AppException;
 import com.limito.limitoresellproduct.application.service.ResellStockService;
 import com.limito.limitoresellproduct.presentation.dto.request.StockReduceRequest;
 import com.limito.limitoresellproduct.presentation.dto.request.StockRollbackRequest;
+import com.limito.limitoresellproduct.presentation.dto.response.InternalResponse;
+import com.limito.limitoresellproduct.presentation.dto.response.StockReduceResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.StockReserveResponseV1;
 
 import jakarta.validation.Valid;
@@ -29,24 +31,17 @@ public class ResellProductInternalController {
 	private final ResellStockService resellStockService;
 
 	@PostMapping("/reserve")
-	public ResponseEntity<StockReserveResponseV1> reserveStock(@RequestBody List<UUID> stockIds) {
+	public ResponseEntity<InternalResponse> reserveStock(@RequestBody List<UUID> stockIds) {
 		// checkRole("USER");
 		StockReserveResponseV1 response = resellStockService.reserveStocks(stockIds);
-		if (response == null) {
-			return ResponseEntity.status(HttpStatus.OK).body(null);
-		}
-		if (response.getErrorCode().equals("E001")) {
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-		}
-		if (response.getErrorCode().equals("E002")) {
-			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-		}
-		return null;
+		return makeResponseWithHttpStatus(response);
 	}
 
 	@PostMapping("/reduce")
-	public ResponseEntity<Object> reduceStock(@Valid @RequestBody List<StockReduceRequest> request) {
-		return ResponseEntity.status(HttpStatus.OK).body(null);
+	public ResponseEntity<InternalResponse> reduceStock(@Valid @RequestBody List<StockReduceRequest> request) {
+		checkRole("USER");
+		StockReduceResponseV1 response = resellStockService.reduceStocks(request);
+		return makeResponseWithHttpStatus(response);
 	}
 
 	@PostMapping("/cancel")
@@ -64,5 +59,18 @@ public class ResellProductInternalController {
 		if (!role.equals(expectedRole)) {
 			throw new AppException(CommonErrorCode.FORBIDDEN);
 		}
+	}
+
+	private ResponseEntity<InternalResponse> makeResponseWithHttpStatus(InternalResponse response) {
+		if (response == null) {
+			return ResponseEntity.status(HttpStatus.OK).body(null);
+		}
+		if (response.getErrorCode().equals("E001")) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+		}
+		if (response.getErrorCode().equals("E002")) {
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+		}
+		return null;
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/request/StockReduceRequest.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/request/StockReduceRequest.java
@@ -3,7 +3,9 @@ package com.limito.limitoresellproduct.presentation.dto.request;
 import java.util.UUID;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
+@Getter
 public class StockReduceRequest {
 
 	@NotNull

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/InternalResponse.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/InternalResponse.java
@@ -1,0 +1,13 @@
+package com.limito.limitoresellproduct.presentation.dto.response;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface InternalResponse {
+
+	public String getErrorCode();
+
+	public String getMessage();
+
+	public List<UUID> getStockIds();
+}

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/StockReduceResponseV1.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/StockReduceResponseV1.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 
 @Getter
 @Builder
-public class StockReserveResponseV1 implements InternalResponse {
+public class StockReduceResponseV1 implements InternalResponse {
 
 	private String errorCode;
 
@@ -17,5 +17,4 @@ public class StockReserveResponseV1 implements InternalResponse {
 
 	@Setter
 	private List<UUID> stockIds;
-
 }


### PR DESCRIPTION
<!-- 제목 -->


<!-- 템플릿 내용 -->
#17

### 변경사항

- internal 컨트롤러 앤드포인트 추가
- DTO 및 에러코드 추가
- 맵퍼 추가
- 재고 redis 레포지토리 delete 메서드 추가
- 재고 jpa 레포지토리 delete, findAllByOptionId 추가
- 재고 차감 서비스 메서드 구현
  - 재고 예약 삭제
  - 재고 삭제
  - 옵션의 최저가 재고 반영

### 리뷰요청

- 