### PR TITLE
[feat] (리셀 상품) internal 상품, 옵션, 재고 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/limito/limitoresellproduct/application/service/ProductStockService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ProductStockService.java
@@ -1,0 +1,35 @@
+package com.limito.limitoresellproduct.application.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.limito.limitoresellproduct.domain.model.Product;
+import com.limito.limitoresellproduct.domain.model.Stock;
+import com.limito.limitoresellproduct.domain.repository.ResellProductRepository;
+import com.limito.limitoresellproduct.domain.repository.ResellStockRepository;
+import com.limito.limitoresellproduct.domain.vo.Option;
+import com.limito.limitoresellproduct.presentation.dto.request.ProductInfosGetRequestV1;
+import com.limito.limitoresellproduct.presentation.dto.response.ProductInfosGetResponseV1;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ProductStockService {
+	private final ResellProductRepository resellProductRepository;
+	private final ResellStockRepository resellStockRepository;
+
+	public List<ProductInfosGetResponseV1> getProdutctInfos(List<ProductInfosGetRequestV1> requests) {
+		List<ProductInfosGetResponseV1> response = requests.stream()
+			.map(request -> {
+				Product product = resellProductRepository.findById(request.getProductId());
+				Option option = product.getOption(request.getOptionId());
+				Stock stock = resellStockRepository.findById(request.getStockId());
+				return ProductInfosGetResponseV1.create(product, option, stock);
+			})
+			.toList();
+
+		return response;
+	}
+}

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ProductStockService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ProductStockService.java
@@ -9,6 +9,7 @@ import com.limito.limitoresellproduct.domain.model.Stock;
 import com.limito.limitoresellproduct.domain.repository.ResellProductRepository;
 import com.limito.limitoresellproduct.domain.repository.ResellStockRepository;
 import com.limito.limitoresellproduct.domain.vo.Option;
+import com.limito.limitoresellproduct.infrastructure.persistence.mapper.ProductMapper;
 import com.limito.limitoresellproduct.presentation.dto.request.ProductInfosGetRequestV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductInfosGetResponseV1;
 
@@ -26,7 +27,7 @@ public class ProductStockService {
 				Product product = resellProductRepository.findById(request.getProductId());
 				Option option = product.getOption(request.getOptionId());
 				Stock stock = resellStockRepository.findById(request.getStockId());
-				return ProductInfosGetResponseV1.create(product, option, stock);
+				return ProductMapper.toProductInfosGetResponseV1(product, option, stock);
 			})
 			.toList();
 

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -108,7 +108,7 @@ public class Product {
 
 	public Option getOption(UUID optionId) {
 		return options.stream()
-			.filter(option -> option.isId(optionId))
+			.filter(option -> option.isEqualId(optionId))
 			.findFirst()
 			.orElse(null);
 	}

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -105,4 +105,11 @@ public class Product {
 			}
 		});
 	}
+
+	public Option getOption(UUID optionId) {
+		return options.stream()
+			.filter(option -> option.isId(optionId))
+			.findFirst()
+			.orElse(null);
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
@@ -8,7 +8,6 @@ import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
-import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -129,7 +128,7 @@ public class Option {
 		}
 	}
 
-	public boolean isEqualId(@NotNull UUID optionId) {
+	public boolean isEqualId(UUID optionId) {
 		return this.optionId.equals(optionId);
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
@@ -8,6 +8,7 @@ import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Embedded;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -126,5 +127,9 @@ public class Option {
 		if (this.minimumPriceStock.getMinimumPriceStockPrice() > newStock.getMinimumPriceStockPrice()) {
 			this.minimumPriceStock = newStock;
 		}
+	}
+
+	public boolean isEqualId(@NotNull UUID optionId) {
+		return this.optionId.equals(optionId);
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/mapper/ProductMapper.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/mapper/ProductMapper.java
@@ -14,6 +14,7 @@ import com.limito.limitoresellproduct.presentation.dto.request.ProductCreateRequ
 import com.limito.limitoresellproduct.presentation.dto.request.StockCreateRequestV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductCreateResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductGetResponseV1;
+import com.limito.limitoresellproduct.presentation.dto.response.ProductInfosGetResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.StockCancelResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.StockCreateResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.StockReduceResponseV1;
@@ -134,6 +135,21 @@ public class ProductMapper {
 			.message(failReason.getMessage()
 				.substring(7))
 			.stockIds(stockIds)
+			.build();
+	}
+
+	public static ProductInfosGetResponseV1 toProductInfosGetResponseV1(Product product, Option option, Stock stock) {
+		return ProductInfosGetResponseV1.builder()
+			.productId(product.getProductId())
+			.optionId(option.getOptionId())
+			.stockId(stock.getId())
+			.productType("RESELL")
+			.productName(product.getName())
+			.brandName(product.getBrandName())
+			.productColor(option.getColor())
+			.productSize(option.getSize())
+			.productPrice(stock.getPrice())
+			.sellerId(stock.getSellerId())
 			.build();
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
@@ -22,31 +22,31 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/internal/v1/resell-products/stock")
+@RequestMapping("/internal/v1/resell-products")
 @RequiredArgsConstructor
 public class ResellProductInternalController {
 
 	private final ResellStockService resellStockService;
 
-	@PostMapping("/reserve")
+	@PostMapping("/stock/reserve")
 	public ResponseEntity<Void> reserveStock(@RequestBody List<UUID> stockIds) {
 		resellStockService.reserveStocks(stockIds);
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping("/reduce")
+	@PostMapping("/stock/reduce")
 	public ResponseEntity<Void> reduceStock(@Valid @RequestBody List<StockReduceRequest> request) {
 		resellStockService.reduceStocks(request);
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping("/cancel")
+	@PostMapping("/stock/cancel")
 	public ResponseEntity<InternalResponse> cancelStock(@RequestBody List<UUID> stockIds) {
 		resellStockService.cancelStocks(stockIds);
 		return ResponseEntity.ok().build();
 	}
 
-	@PostMapping("/rollback")
+	@PostMapping("/stock/rollback")
 	public ResponseEntity<Object> rollbackStock(@Valid @RequestBody List<StockRollbackRequest> request) {
 		return ResponseEntity.status(HttpStatus.OK).body(null);
 	}

--- a/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/controller/ResellProductInternalController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,10 +14,13 @@ import org.springframework.web.bind.annotation.RestController;
 import com.limito.common.audit.UserContextHolder;
 import com.limito.common.code.CommonErrorCode;
 import com.limito.common.exception.AppException;
+import com.limito.limitoresellproduct.application.service.ProductStockService;
 import com.limito.limitoresellproduct.application.service.ResellStockService;
+import com.limito.limitoresellproduct.presentation.dto.request.ProductInfosGetRequestV1;
 import com.limito.limitoresellproduct.presentation.dto.request.StockReduceRequest;
 import com.limito.limitoresellproduct.presentation.dto.request.StockRollbackRequest;
 import com.limito.limitoresellproduct.presentation.dto.response.InternalResponse;
+import com.limito.limitoresellproduct.presentation.dto.response.ProductInfosGetResponseV1;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 public class ResellProductInternalController {
 
 	private final ResellStockService resellStockService;
+	private final ProductStockService productStockService;
 
 	@PostMapping("/stock/reserve")
 	public ResponseEntity<Void> reserveStock(@RequestBody List<UUID> stockIds) {
@@ -49,6 +54,14 @@ public class ResellProductInternalController {
 	@PostMapping("/stock/rollback")
 	public ResponseEntity<Object> rollbackStock(@Valid @RequestBody List<StockRollbackRequest> request) {
 		return ResponseEntity.status(HttpStatus.OK).body(null);
+	}
+
+	@GetMapping("/productInfo")
+	public ResponseEntity<List<ProductInfosGetResponseV1>> getProductInfos(
+		@RequestBody List<ProductInfosGetRequestV1> request
+	) {
+		List<ProductInfosGetResponseV1> response = productStockService.getProdutctInfos(request);
+		return ResponseEntity.ok().body(response);
 	}
 
 	private void checkRole(String expectedRole) {

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/request/ProductInfosGetRequestV1.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/request/ProductInfosGetRequestV1.java
@@ -1,0 +1,18 @@
+package com.limito.limitoresellproduct.presentation.dto.request;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class ProductInfosGetRequestV1 {
+	@NotNull
+	private UUID productId;
+
+	@NotNull
+	private UUID optionId;
+
+	@NotNull
+	private UUID stockId;
+}

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductInfosGetResponseV1.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductInfosGetResponseV1.java
@@ -2,10 +2,6 @@ package com.limito.limitoresellproduct.presentation.dto.response;
 
 import java.util.UUID;
 
-import com.limito.limitoresellproduct.domain.model.Product;
-import com.limito.limitoresellproduct.domain.model.Stock;
-import com.limito.limitoresellproduct.domain.vo.Option;
-
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,19 +18,4 @@ public class ProductInfosGetResponseV1 {
 	private String productColor;
 	private String productSize;
 	private int productPrice;
-
-	public static ProductInfosGetResponseV1 create(Product product, Option option, Stock stock) {
-		return ProductInfosGetResponseV1.builder()
-			.productId(product.getProductId())
-			.optionId(option.getOptionId())
-			.stockId(stock.getId())
-			.productType("RESELL")
-			.productName(product.getName())
-			.brandName(product.getBrandName())
-			.productColor(option.getColor())
-			.productSize(option.getSize())
-			.productPrice(stock.getPrice())
-			.sellerId(stock.getSellerId())
-			.build();
-	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductInfosGetResponseV1.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductInfosGetResponseV1.java
@@ -1,0 +1,40 @@
+package com.limito.limitoresellproduct.presentation.dto.response;
+
+import java.util.UUID;
+
+import com.limito.limitoresellproduct.domain.model.Product;
+import com.limito.limitoresellproduct.domain.model.Stock;
+import com.limito.limitoresellproduct.domain.vo.Option;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProductInfosGetResponseV1 {
+	private UUID productId;
+	private UUID optionId;
+	private UUID stockId;
+	private String productType;
+	private String productName;
+	private String brandName;
+	private Long sellerId;
+	private String productColor;
+	private String productSize;
+	private int productPrice;
+
+	public static ProductInfosGetResponseV1 create(Product product, Option option, Stock stock) {
+		return ProductInfosGetResponseV1.builder()
+			.productId(product.getProductId())
+			.optionId(option.getOptionId())
+			.stockId(stock.getId())
+			.productType("RESELL")
+			.productName(product.getName())
+			.brandName(product.getBrandName())
+			.productColor(option.getColor())
+			.productSize(option.getSize())
+			.productPrice(stock.getPrice())
+			.sellerId(stock.getSellerId())
+			.build();
+	}
+}


### PR DESCRIPTION
<!-- 제목 -->


<!-- 템플릿 내용 -->
#32

### 변경사항

- 컨트롤러 엔드포인트 추가
- 상품과 재고 도메인에 접근하는 상품-재고 서비스 추가
- 상품 및 재고 정보 가져오는 서비스 메서드 구현
- DTO 구현
- 각 도메인의 정보를 가져오는 도메인 로직 추가

### 리뷰요청

- 