### PR TITLE
[fix] 삭제된 엔티티 조회하면 안 되는 경우 수정

### DIFF
--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -40,6 +40,7 @@ public class ResellProductService {
 		if (product == null) {
 			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
 		}
+		product.checkActive();
 		product.changeMinimumPriceStock(optionId, minimumPriceStock);
 	}
 
@@ -61,10 +62,12 @@ public class ResellProductService {
 		if (product == null) {
 			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
 		}
+		product.checkActive();
 
 		Option option = product.getOption(optionId);
 		if (option == null) {
 			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
 		}
+		option.checkActive();
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -6,10 +6,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import com.limito.common.exception.AppException;
 import com.limito.limitoresellproduct.domain.model.Product;
 import com.limito.limitoresellproduct.domain.repository.ResellProductRepository;
 import com.limito.limitoresellproduct.domain.vo.MinimumPriceStock;
+import com.limito.limitoresellproduct.domain.vo.Option;
 import com.limito.limitoresellproduct.infrastructure.persistence.mapper.ProductMapper;
+import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
 import com.limito.limitoresellproduct.presentation.dto.request.ProductCreateRequestV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductCreateResponseV1;
 import com.limito.limitoresellproduct.presentation.dto.response.ProductGetResponseV1;
@@ -34,6 +37,9 @@ public class ResellProductService {
 	public void changeMinimumPriceStock(UUID productId, UUID optionId, UUID stockId, int price) {
 		MinimumPriceStock minimumPriceStock = new MinimumPriceStock(stockId, price);
 		Product product = resellProductRepository.findById(productId);
+		if (product == null) {
+			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
+		}
 		product.changeMinimumPriceStock(optionId, minimumPriceStock);
 	}
 
@@ -45,5 +51,17 @@ public class ResellProductService {
 	public ProductGetResponseV1 getProduct(UUID resellProductId) {
 		Product product = resellProductRepository.findById(resellProductId);
 		return ProductMapper.toProductGetResponseV1(product);
+	}
+
+	public void validateProductAndOption(UUID productId, UUID optionId) {
+		Product product = resellProductRepository.findById(productId);
+		if (product == null) {
+			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
+		}
+
+		Option option = product.getOption(optionId);
+		if (option == null) {
+			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
+		}
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -44,12 +44,15 @@ public class ResellProductService {
 	}
 
 	public ProductReadResponseV1 getProducts(UUID categoryId, Pageable pageable) {
-		Page<Product> products = resellProductRepository.findAllByCategoryId(categoryId, pageable);
+		Page<Product> products = resellProductRepository.findAllByCategoryIdForAllUser(categoryId, pageable);
 		return ProductReadResponseV1.of(categoryId, products);
 	}
 
 	public ProductGetResponseV1 getProduct(UUID resellProductId) {
-		Product product = resellProductRepository.findById(resellProductId);
+		Product product = resellProductRepository.findByIdForAllUser(resellProductId);
+		if (product == null) {
+			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
+		}
 		return ProductMapper.toProductGetResponseV1(product);
 	}
 

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
@@ -31,17 +31,15 @@ public class ResellStockService {
 
 	private static final String REDIS_STOCK_PREFIX_KEY = "resell-stock:";
 
+	@Transactional
 	public StockCreateResponseV1 createStock(@Valid StockCreateRequestV1 request) {
 		Stock stock = ProductMapper.toEntity(request);
 
+		productService.validateProductAndOption(request.getProductId(), request.getOptionId());
+
 		Stock savedStock = resellStockRepository.saveStock(stock);
 
-		productService.changeMinimumPriceStock(
-			request.getProductId(),
-			savedStock.getOptionId(),
-			savedStock.getId(),
-			savedStock.getPrice()
-		);
+		refreshMinStockOfOption(request.getProductId(), request.getOptionId());
 
 		return ProductMapper.toStockCreateResponseV1(savedStock);
 	}

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
@@ -53,9 +53,11 @@ public class ResellStockService {
 	private void reserveStock(UUID stockId) {
 		String key = REDIS_STOCK_PREFIX_KEY + stockId;
 
-		if (resellStockRepository.findById(stockId) == null) {
+		Stock stock = resellStockRepository.findById(stockId);
+		if (stock == null) {
 			throw new AppException(ProductErrorCode.WRONG_STOCK_ID);
 		}
+		stock.checkActive();
 
 		if (stockInMemoryRepository.get(key) != null) {
 			throw new AppException(ProductErrorCode.OUT_OF_STOCK);
@@ -104,10 +106,7 @@ public class ResellStockService {
 		if (stock == null) {
 			throw new AppException(ProductErrorCode.WRONG_STOCK_ID);
 		}
-
-		if (stock.isSoldOut()) {
-			throw new AppException(ProductErrorCode.OUT_OF_STOCK);
-		}
+		stock.checkActive();
 
 		stock.changeSoldOutTo(true);
 	}
@@ -129,6 +128,10 @@ public class ResellStockService {
 		Stock stock = resellStockRepository.findById(request.getStockId());
 		if (stock == null) {
 			throw new AppException(ProductErrorCode.WRONG_STOCK_ID);
+		}
+
+		if (!stock.isSoldOut()) {
+			throw new AppException(ProductErrorCode.ALREADY_EXIST);
 		}
 
 		stock.changeSoldOutTo(false);

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -3,6 +3,7 @@ package com.limito.limitoresellproduct.domain.model;
 import java.util.List;
 import java.util.UUID;
 
+import com.limito.common.audit.BaseEntity;
 import com.limito.common.exception.AppException;
 import com.limito.limitoresellproduct.domain.vo.MinimumPriceStock;
 import com.limito.limitoresellproduct.domain.vo.Option;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_resell_products")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Product {
+public class Product extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -100,7 +100,12 @@ public class Product extends BaseEntity {
 	}
 
 	public void changeMinimumPriceStock(UUID optionId, MinimumPriceStock newStock) {
-		this.getOption(optionId).changeMinimumPriceStock(newStock);
+		Option option = this.getOption(optionId);
+		if (option == null) {
+			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
+		}
+		option.checkActive();
+		option.changeMinimumPriceStock(newStock);
 	}
 
 	public Option getOption(UUID optionId) {
@@ -108,5 +113,11 @@ public class Product extends BaseEntity {
 			.filter(option -> option.isEqualId(optionId))
 			.findFirst()
 			.orElse(null);
+	}
+
+	public void checkActive() {
+		if (this.isDeleted()) {
+			throw new AppException(ProductErrorCode.INACTIVE_PRODUCT);
+		}
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -99,11 +99,7 @@ public class Product {
 	}
 
 	public void changeMinimumPriceStock(UUID optionId, MinimumPriceStock newStock) {
-		this.options.forEach(option -> {
-			if (option.getOptionId().equals(optionId)) {
-				option.changeMinimumPriceStock(newStock);
-			}
-		});
+		this.getOption(optionId).changeMinimumPriceStock(newStock);
 	}
 
 	public Option getOption(UUID optionId) {

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
@@ -3,6 +3,7 @@ package com.limito.limitoresellproduct.domain.model;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.limito.common.audit.BaseEntity;
 import com.limito.common.audit.UserContextHolder;
 import com.limito.common.exception.AppException;
 import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_resell_product_stocks")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Stock {
+public class Stock extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
@@ -82,4 +82,13 @@ public class Stock extends BaseEntity {
 	public void changeSoldOutTo(boolean soldOut) {
 		this.soldOut = soldOut;
 	}
+
+	public void checkActive() {
+		if (this.isDeleted()) {
+			throw new AppException(ProductErrorCode.INACTIVE_STOCK);
+		}
+		if (this.soldOut) {
+			throw new AppException(ProductErrorCode.OUT_OF_STOCK);
+		}
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stocks.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stocks.java
@@ -8,6 +8,8 @@ public class Stocks {
 
 	public static Stock calculateMinStock(List<Stock> stocks) {
 		Stock minStock = stocks.stream()
+			.filter(stock -> !stock.isDeleted())
+			.filter(stock -> !stock.isSoldOut())
 			.min(Comparator.comparing(Stock::getPrice))
 			.orElse(null);
 

--- a/src/main/java/com/limito/limitoresellproduct/domain/repository/ResellProductRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/repository/ResellProductRepository.java
@@ -13,5 +13,7 @@ public interface ResellProductRepository {
 
 	Product findById(UUID productId);
 
-	Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable);
+	Product findByIdForAllUser(UUID productId);
+
+	Page<Product> findAllByCategoryIdForAllUser(UUID categoryId, Pageable pageable);
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/vo/MinimumPriceStock.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/vo/MinimumPriceStock.java
@@ -14,20 +14,20 @@ import lombok.NoArgsConstructor;
 public class MinimumPriceStock {
 
 	@Column(name = "min_price_stock_id")
-	private UUID minimumPriceStockId;
+	private UUID stockId;
 
 	@Column(name = "min_price_stock_price")
-	private int minimumPriceStockPrice;
+	private int price;
 
 	public MinimumPriceStock(UUID stockId, Integer price) {
-		this.minimumPriceStockId = stockId;
+		this.stockId = stockId;
 		setPrice(price);
 	}
 
 	private void setPrice(Integer price) {
 		if (price == null) {
-			price = -1;
+			price = 0;
 		}
-		this.minimumPriceStockPrice = price;
+		this.price = price;
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
@@ -132,4 +132,7 @@ public class Option {
 	public boolean isEqualId(UUID optionId) {
 		return this.optionId.equals(optionId);
 	}
+
+	public void checkActive() {
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
@@ -35,6 +35,9 @@ public class Option {
 	@Column(name = "details", columnDefinition = "TEXT")
 	private String details;
 
+	@Column(name = "inStock", nullable = false)
+	private boolean inStock = false;
+
 	@Embedded
 	private MinimumPriceStock minimumPriceStock;
 
@@ -107,24 +110,22 @@ public class Option {
 	}
 
 	private void setMinimumPriceStock(MinimumPriceStock stock) {
+		this.inStock = true;
 		if (stock == null) {
 			stock = new MinimumPriceStock(null, null);
+			this.inStock = false;
 		}
 		this.minimumPriceStock = stock;
 	}
 
-	public void changeMinimumPriceStock(MinimumPriceStock newStock) {
-		if (this.minimumPriceStock == null) {
-			this.minimumPriceStock = new MinimumPriceStock(null, null);
+	public void changeMinimumPriceStock(MinimumPriceStock newMinStock) {
+		this.minimumPriceStock = newMinStock;
+
+		if (newMinStock != null) {
+			this.inStock = true;
 		}
-		if (newStock == null) {
-			newStock = new MinimumPriceStock(null, null);
-		}
-		if (this.minimumPriceStock.getMinimumPriceStockPrice() < 0) {
-			this.minimumPriceStock = newStock;
-		}
-		if (this.minimumPriceStock.getMinimumPriceStockPrice() > newStock.getMinimumPriceStockPrice()) {
-			this.minimumPriceStock = newStock;
+		if (newMinStock == null) {
+			this.inStock = false;
 		}
 	}
 

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/mapper/ProductMapper.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/mapper/ProductMapper.java
@@ -64,9 +64,10 @@ public class ProductMapper {
 					o.getColor(),
 					o.getThumbnailUrl(),
 					o.getDetails(),
+					o.isInStock(),
 					new ProductCreateResponseV1.MinStockResponse(
-						o.getMinimumPriceStock().getMinimumPriceStockId(),
-						o.getMinimumPriceStock().getMinimumPriceStockPrice()
+						o.getMinimumPriceStock().getStockId(),
+						o.getMinimumPriceStock().getPrice()
 					)
 				))
 				.toList())
@@ -93,8 +94,8 @@ public class ProductMapper {
 				ProductGetResponseV1.ProductGetResponseMinStock minStockRes = null;
 				if (stock != null) {
 					minStockRes = new ProductGetResponseV1.ProductGetResponseMinStock(
-						stock.getMinimumPriceStockId(),
-						stock.getMinimumPriceStockPrice()
+						stock.getStockId(),
+						stock.getPrice()
 					);
 				}
 

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductJpaRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductJpaRepository.java
@@ -1,5 +1,6 @@
 package com.limito.limitoresellproduct.infrastructure.persistence.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -10,4 +11,8 @@ import com.limito.limitoresellproduct.domain.model.Product;
 
 public interface ResellProductJpaRepository extends JpaRepository<Product, UUID> {
 	Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable);
+
+	Page<Product> findAllByCategoryIdAndDeletedAtIsNull(UUID categoryId, Pageable pageable);
+
+	Optional<Product> findByProductIdAndDeletedAtIsNull(UUID productId);
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductRepositoryImpl.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductRepositoryImpl.java
@@ -31,4 +31,14 @@ public class ResellProductRepositoryImpl implements ResellProductRepository {
 	public Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable) {
 		return jpaRepository.findAllByCategoryId(categoryId, pageable);
 	}
+
+	@Override
+	public Product findByIdForAllUser(UUID productId) {
+		return jpaRepository.findByProductIdAndDeletedAtIsNull(productId).orElse(null);
+	}
+
+	@Override
+	public Page<Product> findAllByCategoryIdForAllUser(UUID categoryId, Pageable pageable) {
+		return jpaRepository.findAllByCategoryIdAndDeletedAtIsNull(categoryId, pageable);
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
@@ -14,7 +14,10 @@ public enum ProductErrorCode implements ErrorCode {
 	WRONG_PRODUCT_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 ID입니다."),
 	WRONG_OPTION_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 옵션 ID입니다."),
 	WRONG_STOCK_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 재고 ID입니다."),
-	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족");
+	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족"),
+	INACTIVE_PRODUCT(HttpStatus.BAD_REQUEST, "비활성화된 상품입니다."),
+	INACTIVE_OPTION(HttpStatus.BAD_REQUEST, "비활성화된 옵션입니다."),
+	INACTIVE_STOCK(HttpStatus.BAD_REQUEST, "비활성화된 재고입니다.");
 
 	private HttpStatus status;
 	private String message;

--- a/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
@@ -11,8 +11,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ProductErrorCode implements ErrorCode {
 	INVALID_DOMAIN_INFO(HttpStatus.BAD_REQUEST, "잘못된 도메인 정보입니다."),
-	WRONG_STOCK_ID(HttpStatus.BAD_REQUEST, "E001 : 잘못된 리셀 상품 재고 ID입니다."),
-	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "E002 : 재고 부족");
+	WRONG_PRODUCT_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 ID입니다."),
+	WRONG_OPTION_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 옵션 ID입니다."),
+	WRONG_STOCK_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 재고 ID입니다."),
+	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족");
 
 	private HttpStatus status;
 	private String message;

--- a/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
@@ -17,7 +17,8 @@ public enum ProductErrorCode implements ErrorCode {
 	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족"),
 	INACTIVE_PRODUCT(HttpStatus.BAD_REQUEST, "비활성화된 상품입니다."),
 	INACTIVE_OPTION(HttpStatus.BAD_REQUEST, "비활성화된 옵션입니다."),
-	INACTIVE_STOCK(HttpStatus.BAD_REQUEST, "비활성화된 재고입니다.");
+	INACTIVE_STOCK(HttpStatus.BAD_REQUEST, "비활성화된 재고입니다."),
+	ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 재고가 존재합니다.");
 
 	private HttpStatus status;
 	private String message;

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductCreateResponseV1.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductCreateResponseV1.java
@@ -34,6 +34,7 @@ public class ProductCreateResponseV1 {
 		String color,
 		String thumbnailUrl,
 		String details,
+		boolean inStock,
 		MinStockResponse minStock
 	) {
 	}

--- a/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductReadResponseV1.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/dto/response/ProductReadResponseV1.java
@@ -57,8 +57,8 @@ public class ProductReadResponseV1 {
 					MinStockReadRes minStockRes = null;
 					if (stock != null) {
 						minStockRes = new MinStockReadRes(
-							stock.getMinimumPriceStockId(),
-							stock.getMinimumPriceStockPrice()
+							stock.getStockId(),
+							stock.getPrice()
 						);
 					}
 


### PR DESCRIPTION
<!-- 제목 -->


<!-- 템플릿 내용 -->
#41

### 변경사항

- BaseEntity 상속
- 삭제된 상품 조회되지 않게 수정
  - 삭제된 상품 제외하고 상품들 조회하는 레포지토리 메서드 추가
  - 상품 조회 시 삭제된 상품 제외하고 조회하도록 변경
  - 활성화된 상품 및 옵션에 대해 작업하도록 변경
- 삭제되거나 품절된 재고는 조회되지 않게 수정

### 리뷰요청

- 