### PR TITLE
[fix] 삭제된 엔티티 조회하면 안 되는 경우 수정

### DIFF
--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -40,6 +40,7 @@ public class ResellProductService {
 		if (product == null) {
 			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
 		}
+		product.checkActive();
 		product.changeMinimumPriceStock(optionId, minimumPriceStock);
 	}
 
@@ -61,10 +62,12 @@ public class ResellProductService {
 		if (product == null) {
 			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
 		}
+		product.checkActive();
 
 		Option option = product.getOption(optionId);
 		if (option == null) {
 			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
 		}
+		option.checkActive();
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -44,12 +44,15 @@ public class ResellProductService {
 	}
 
 	public ProductReadResponseV1 getProducts(UUID categoryId, Pageable pageable) {
-		Page<Product> products = resellProductRepository.findAllByCategoryId(categoryId, pageable);
+		Page<Product> products = resellProductRepository.findAllByCategoryIdForAllUser(categoryId, pageable);
 		return ProductReadResponseV1.of(categoryId, products);
 	}
 
 	public ProductGetResponseV1 getProduct(UUID resellProductId) {
-		Product product = resellProductRepository.findById(resellProductId);
+		Product product = resellProductRepository.findByIdForAllUser(resellProductId);
+		if (product == null) {
+			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
+		}
 		return ProductMapper.toProductGetResponseV1(product);
 	}
 

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellProductService.java
@@ -40,7 +40,7 @@ public class ResellProductService {
 		if (product == null) {
 			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
 		}
-		product.checkActive();
+		product.validateActive();
 		product.changeMinimumPriceStock(optionId, minimumPriceStock);
 	}
 
@@ -62,7 +62,7 @@ public class ResellProductService {
 		if (product == null) {
 			throw new AppException(ProductErrorCode.WRONG_PRODUCT_ID);
 		}
-		product.checkActive();
+		product.validateActive();
 
 		Option option = product.getOption(optionId);
 		if (option == null) {

--- a/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
+++ b/src/main/java/com/limito/limitoresellproduct/application/service/ResellStockService.java
@@ -53,9 +53,11 @@ public class ResellStockService {
 	private void reserveStock(UUID stockId) {
 		String key = REDIS_STOCK_PREFIX_KEY + stockId;
 
-		if (resellStockRepository.findById(stockId) == null) {
+		Stock stock = resellStockRepository.findById(stockId);
+		if (stock == null) {
 			throw new AppException(ProductErrorCode.WRONG_STOCK_ID);
 		}
+		stock.checkActive();
 
 		if (stockInMemoryRepository.get(key) != null) {
 			throw new AppException(ProductErrorCode.OUT_OF_STOCK);
@@ -104,10 +106,7 @@ public class ResellStockService {
 		if (stock == null) {
 			throw new AppException(ProductErrorCode.WRONG_STOCK_ID);
 		}
-
-		if (stock.isSoldOut()) {
-			throw new AppException(ProductErrorCode.OUT_OF_STOCK);
-		}
+		stock.checkActive();
 
 		stock.changeSoldOutTo(true);
 	}
@@ -129,6 +128,10 @@ public class ResellStockService {
 		Stock stock = resellStockRepository.findById(request.getStockId());
 		if (stock == null) {
 			throw new AppException(ProductErrorCode.WRONG_STOCK_ID);
+		}
+
+		if (!stock.isSoldOut()) {
+			throw new AppException(ProductErrorCode.ALREADY_EXIST);
 		}
 
 		stock.changeSoldOutTo(false);

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -3,6 +3,7 @@ package com.limito.limitoresellproduct.domain.model;
 import java.util.List;
 import java.util.UUID;
 
+import com.limito.common.audit.BaseEntity;
 import com.limito.common.exception.AppException;
 import com.limito.limitoresellproduct.domain.vo.MinimumPriceStock;
 import com.limito.limitoresellproduct.domain.vo.Option;
@@ -26,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_resell_products")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Product {
+public class Product extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -100,7 +100,12 @@ public class Product extends BaseEntity {
 	}
 
 	public void changeMinimumPriceStock(UUID optionId, MinimumPriceStock newStock) {
-		this.getOption(optionId).changeMinimumPriceStock(newStock);
+		Option option = this.getOption(optionId);
+		if (option == null) {
+			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
+		}
+		option.checkActive();
+		option.changeMinimumPriceStock(newStock);
 	}
 
 	public Option getOption(UUID optionId) {
@@ -108,5 +113,11 @@ public class Product extends BaseEntity {
 			.filter(option -> option.isEqualId(optionId))
 			.findFirst()
 			.orElse(null);
+	}
+
+	public void checkActive() {
+		if (this.isDeleted()) {
+			throw new AppException(ProductErrorCode.INACTIVE_PRODUCT);
+		}
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -112,7 +112,7 @@ public class Product extends BaseEntity {
 			.orElse(null);
 	}
 
-	public void checkActive() {
+	public void validateActive() {
 		if (this.isDeleted()) {
 			throw new AppException(ProductErrorCode.INACTIVE_PRODUCT);
 		}

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Product.java
@@ -100,11 +100,8 @@ public class Product extends BaseEntity {
 	}
 
 	public void changeMinimumPriceStock(UUID optionId, MinimumPriceStock newStock) {
+		this.validOptionActive(optionId);
 		Option option = this.getOption(optionId);
-		if (option == null) {
-			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
-		}
-		option.checkActive();
 		option.changeMinimumPriceStock(newStock);
 	}
 
@@ -119,5 +116,14 @@ public class Product extends BaseEntity {
 		if (this.isDeleted()) {
 			throw new AppException(ProductErrorCode.INACTIVE_PRODUCT);
 		}
+	}
+
+	private void validOptionActive(UUID optionId) {
+		Option option = this.getOption(optionId);
+		if (option == null) {
+			throw new AppException(ProductErrorCode.WRONG_OPTION_ID);
+		}
+
+		option.checkActive();
 	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
@@ -3,6 +3,7 @@ package com.limito.limitoresellproduct.domain.model;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.limito.common.audit.BaseEntity;
 import com.limito.common.audit.UserContextHolder;
 import com.limito.common.exception.AppException;
 import com.limito.limitoresellproduct.presentation.advice.ProductErrorCode;
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "p_resell_product_stocks")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Stock {
+public class Stock extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.UUID)

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stock.java
@@ -82,4 +82,13 @@ public class Stock extends BaseEntity {
 	public void changeSoldOutTo(boolean soldOut) {
 		this.soldOut = soldOut;
 	}
+
+	public void checkActive() {
+		if (this.isDeleted()) {
+			throw new AppException(ProductErrorCode.INACTIVE_STOCK);
+		}
+		if (this.soldOut) {
+			throw new AppException(ProductErrorCode.OUT_OF_STOCK);
+		}
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/model/Stocks.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/model/Stocks.java
@@ -8,6 +8,8 @@ public class Stocks {
 
 	public static Stock calculateMinStock(List<Stock> stocks) {
 		Stock minStock = stocks.stream()
+			.filter(stock -> !stock.isDeleted())
+			.filter(stock -> !stock.isSoldOut())
 			.min(Comparator.comparing(Stock::getPrice))
 			.orElse(null);
 

--- a/src/main/java/com/limito/limitoresellproduct/domain/repository/ResellProductRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/repository/ResellProductRepository.java
@@ -13,5 +13,7 @@ public interface ResellProductRepository {
 
 	Product findById(UUID productId);
 
-	Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable);
+	Product findByIdForAllUser(UUID productId);
+
+	Page<Product> findAllByCategoryIdForAllUser(UUID categoryId, Pageable pageable);
 }

--- a/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
+++ b/src/main/java/com/limito/limitoresellproduct/domain/vo/Option.java
@@ -132,4 +132,7 @@ public class Option {
 	public boolean isEqualId(UUID optionId) {
 		return this.optionId.equals(optionId);
 	}
+
+	public void checkActive() {
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductJpaRepository.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductJpaRepository.java
@@ -1,5 +1,6 @@
 package com.limito.limitoresellproduct.infrastructure.persistence.repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Page;
@@ -10,4 +11,8 @@ import com.limito.limitoresellproduct.domain.model.Product;
 
 public interface ResellProductJpaRepository extends JpaRepository<Product, UUID> {
 	Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable);
+
+	Page<Product> findAllByCategoryIdAndDeletedAtIsNull(UUID categoryId, Pageable pageable);
+
+	Optional<Product> findByProductIdAndDeletedAtIsNull(UUID productId);
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductRepositoryImpl.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductRepositoryImpl.java
@@ -31,4 +31,14 @@ public class ResellProductRepositoryImpl implements ResellProductRepository {
 	public Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable) {
 		return jpaRepository.findAllByCategoryId(categoryId, pageable);
 	}
+
+	@Override
+	public Product findByIdForAllUser(UUID productId) {
+		return jpaRepository.findByProductIdAndDeletedAtIsNull(productId).orElse(null);
+	}
+
+	@Override
+	public Page<Product> findAllByCategoryIdForAllUser(UUID categoryId, Pageable pageable) {
+		return jpaRepository.findAllByCategoryIdAndDeletedAtIsNull(categoryId, pageable);
+	}
 }

--- a/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductRepositoryImpl.java
+++ b/src/main/java/com/limito/limitoresellproduct/infrastructure/persistence/repository/ResellProductRepositoryImpl.java
@@ -28,11 +28,6 @@ public class ResellProductRepositoryImpl implements ResellProductRepository {
 	}
 
 	@Override
-	public Page<Product> findAllByCategoryId(UUID categoryId, Pageable pageable) {
-		return jpaRepository.findAllByCategoryId(categoryId, pageable);
-	}
-
-	@Override
 	public Product findByIdForAllUser(UUID productId) {
 		return jpaRepository.findByProductIdAndDeletedAtIsNull(productId).orElse(null);
 	}

--- a/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
@@ -14,7 +14,10 @@ public enum ProductErrorCode implements ErrorCode {
 	WRONG_PRODUCT_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 ID입니다."),
 	WRONG_OPTION_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 옵션 ID입니다."),
 	WRONG_STOCK_ID(HttpStatus.BAD_REQUEST, "잘못된 리셀 상품 재고 ID입니다."),
-	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족");
+	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족"),
+	INACTIVE_PRODUCT(HttpStatus.BAD_REQUEST, "비활성화된 상품입니다."),
+	INACTIVE_OPTION(HttpStatus.BAD_REQUEST, "비활성화된 옵션입니다."),
+	INACTIVE_STOCK(HttpStatus.BAD_REQUEST, "비활성화된 재고입니다.");
 
 	private HttpStatus status;
 	private String message;

--- a/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
+++ b/src/main/java/com/limito/limitoresellproduct/presentation/advice/ProductErrorCode.java
@@ -17,7 +17,8 @@ public enum ProductErrorCode implements ErrorCode {
 	OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고 부족"),
 	INACTIVE_PRODUCT(HttpStatus.BAD_REQUEST, "비활성화된 상품입니다."),
 	INACTIVE_OPTION(HttpStatus.BAD_REQUEST, "비활성화된 옵션입니다."),
-	INACTIVE_STOCK(HttpStatus.BAD_REQUEST, "비활성화된 재고입니다.");
+	INACTIVE_STOCK(HttpStatus.BAD_REQUEST, "비활성화된 재고입니다."),
+	ALREADY_EXIST(HttpStatus.BAD_REQUEST, "이미 재고가 존재합니다.");
 
 	private HttpStatus status;
 	private String message;


### PR DESCRIPTION
<!-- 제목 -->


<!-- 템플릿 내용 -->
#41

### 변경사항

- BaseEntity 상속
- 삭제된 상품 제외하고 상품들 조회하는 레포지토리 메서드 추가
- 상품 조회 시 삭제된 상품 제외하고 조회하도록 변경
- 활성화된 상품 및 옵션에 대해 작업하도록 변경
- 삭제되거나 품절된 재고는 조회되지 않게 수정
- 레포지토리 구현체에서 필요없는 메서드 제거

### 리뷰요청

- 